### PR TITLE
Reduce deprecation warning

### DIFF
--- a/lib/akane/recorder.rb
+++ b/lib/akane/recorder.rb
@@ -59,7 +59,7 @@ module Akane
 
       @storages.each do |storage|
         begin
-          timeout(@timeout) do
+          Timeout.timeout(@timeout) do
             storage.__send__(action, account, *payload)
           end
 

--- a/lib/akane/recorder.rb
+++ b/lib/akane/recorder.rb
@@ -79,7 +79,7 @@ module Akane
     end
 
     def run(raise_errors = false)
-      @running_thread = Thread.new do 
+      @running_thread = Thread.new do
         loop do
           begin
             begin


### PR DESCRIPTION
in ruby 2.3.0 warns like:

```
..../2.3.0/gems/akane-0.3.0/lib/akane/recorder.rb:62:in `block in perform': Object#timeout is deprecated, use Timeout.timeout instead.
```
